### PR TITLE
Add arena world manager and UI integration

### DIFF
--- a/resources/erotic-core/client/custom_worlds.lua
+++ b/resources/erotic-core/client/custom_worlds.lua
@@ -1,0 +1,42 @@
+local lobbySpawn = vector4(231.15, -1390.96, 30.49, 339.39)
+
+RegisterNetEvent("erotic-core:customWorldEnter", function(data)
+    core.currentMode = "custom"
+    core.applyGameSettings("custom")
+
+    local spawn = data and data.spawn or core.gamemodeSettings.custom.defaultSpawn or core.spawnCoords
+    local ped = PlayerPedId()
+
+    if IsEntityDead(ped) then
+        ResurrectPed(ped)
+        ClearPedTasksImmediately(ped)
+    end
+
+    SetEntityHealth(ped, 200)
+    AddArmourToPed(ped, 100)
+
+    SetEntityCoordsNoOffset(ped, spawn.x, spawn.y, spawn.z, false, false, false, true)
+    SetEntityHeading(ped, spawn.w)
+
+    local worldName = (data and data.name) or "Personal Arena"
+    print(("[erotic-core] Entered %s"):format(worldName))
+end)
+
+RegisterNetEvent("erotic-core:customWorldExit", function()
+    core.currentMode = "lobby"
+    local ped = PlayerPedId()
+    local spawn = lobbySpawn
+
+    if IsEntityDead(ped) then
+        ResurrectPed(ped)
+        ClearPedTasksImmediately(ped)
+    end
+
+    SetEntityHealth(ped, 200)
+    AddArmourToPed(ped, 100)
+
+    SetEntityCoordsNoOffset(ped, spawn.x, spawn.y, spawn.z, false, false, false, true)
+    SetEntityHeading(ped, spawn.w)
+
+    print("[erotic-core] Left custom arena. Returning to lobby.")
+end)

--- a/resources/erotic-core/fxmanifest.lua
+++ b/resources/erotic-core/fxmanifest.lua
@@ -7,13 +7,18 @@ author "Jeridin"
 version "1.0.0"
 
 shared_scripts {
-	'shared/*.lua'
+    'shared/*.lua'
 }
 
 client_scripts {
-	'client/*.lua'
+    'client/*.lua'
 }
 
 server_scripts {
-	'server/*.lua'
+    'server/worlds.lua',
+    'server/users.lua',
+    'server/events.lua',
+    'server/queue.lua',
+    'server/matches.lua',
+    'server/ffa.lua'
 }

--- a/resources/erotic-core/server/ffa.lua
+++ b/resources/erotic-core/server/ffa.lua
@@ -1,51 +1,34 @@
-core.ffaPlayers = core.ffaPlayers or {}
+local function joinFFA(src)
+    local ok, err = core.joinGamemode(src, "ffa")
+    if not ok then
+        if err == "World is full" then
+            TriggerClientEvent("chat:addMessage", src, { args = { "[Arena]", "FFA is currently full." } })
+        elseif err == "Finish your current match before switching arenas." then
+            TriggerClientEvent("chat:addMessage", src, { args = { "[Arena]", err } })
+        else
+            TriggerClientEvent("chat:addMessage", src, { args = { "[Arena]", err or "Unable to join FFA right now." } })
+        end
+        return
+    end
+
+    TriggerClientEvent("chat:addMessage", src, { args = { "[Arena]", "You entered the Free-For-All arena." } })
+end
+
+local function leaveFFA(src)
+    local world = core.getWorldByPlayer(src)
+    if not world or world.gamemode ~= "ffa" then
+        TriggerClientEvent("chat:addMessage", src, { args = { "[Arena]", "You are not in FFA." } })
+        return
+    end
+
+    core.leaveCurrentWorld(src, "ui")
+    TriggerClientEvent("chat:addMessage", src, { args = { "[Arena]", "You left the Free-For-All arena." } })
+end
 
 RegisterCommand("joinffa", function(src)
-    local settings = core.gamemodeSettings.ffa
-    if not settings then return end
-
-    SetPlayerRoutingBucket(src, settings.bucket)
-    core.ffaPlayers[src] = true
-
-    TriggerClientEvent("erotic-core:ffaEnter", src, settings.spawns)
-
-    -- update blips for *all* players in FFA
-    core.updateFFABlips()
-
-    print(("[erotic-core] %s joined FFA"):format(GetPlayerName(src)))
+    joinFFA(src)
 end, false)
 
 RegisterCommand("leaveffa", function(src)
-    core.ffaPlayers[src] = nil
-    SetPlayerRoutingBucket(src, 0)
-    TriggerClientEvent("erotic-core:setMode", src, "lobby")
-
-    TriggerClientEvent("erotic-core:ffaExit", src)
-
-    -- update blips for the rest
-    core.updateFFABlips()
-
-    print(("[erotic-core] %s left FFA"):format(GetPlayerName(src)))
+    leaveFFA(src)
 end, false)
-
-AddEventHandler("playerDropped", function()
-    core.ffaPlayers[source] = nil
-    core.updateFFABlips()
-end)
-
--- helper to rebuild blip lists for all FFA players
-function core.updateFFABlips()
-    local settings = core.gamemodeSettings.ffa
-    if not settings.blips then return end
-
-    -- collect all current FFA player IDs
-    local players = {}
-    for id, _ in pairs(core.ffaPlayers) do
-        table.insert(players, id)
-    end
-
-    -- tell everyone in FFA who to track
-    for id, _ in pairs(core.ffaPlayers) do
-        TriggerClientEvent("erotic-core:enableBlips", id, players, settings.blipInterval or 3000)
-    end
-end

--- a/resources/erotic-core/server/matches.lua
+++ b/resources/erotic-core/server/matches.lua
@@ -1,6 +1,5 @@
 core = core or {}
 core.matches = core.matches or {}
-core.nextBucket = core.nextBucket or 1
 
 -- Create a match. For duel: players={p1,p2}. For 4v4: players has 8 and we split into A/B.
 function core.createMatch(players, gamemode)
@@ -15,8 +14,16 @@ function core.createMatch(players, gamemode)
         return
     end
 
-    local bucketId = core.nextBucket
-    core.nextBucket = core.nextBucket + 1
+    local bucketId = core.allocateBucket()
+
+    local world = core.registerWorld(bucketId, gamemode, "match", {
+        players = players,
+        metadata = {
+            name = settings.world and settings.world.name or (gamemode .. " Match"),
+            queue = true
+        },
+        capacity = settings.world and settings.world.capacity or #players
+    })
 
     local match = {
         id = bucketId,
@@ -47,6 +54,9 @@ function core.createMatch(players, gamemode)
         SetPlayerRoutingBucket(src, bucketId)
         TriggerClientEvent("erotic-core:setMode", src, gamemode)        -- switch mode
         TriggerClientEvent("erotic-core:applyGameSettings", src, gamemode) -- apply mode settings
+        if world then
+            world.players[src] = true
+        end
     end
 
     -- optional blips per settings
@@ -175,4 +185,41 @@ function core.endMatch(bucketId, winningSide)
         :format(bucketId, tostring(winningSide), match.scores.A, match.scores.B))
 
     core.matches[bucketId] = nil
+    core.unregisterWorld(bucketId)
+end
+
+function core.handleMatchPlayerLeft(src, reason)
+    local bucketId = GetPlayerRoutingBucket(src)
+    local match = core.matches[bucketId]
+    if not match then return end
+
+    local playerName = GetPlayerName(src) or ("Player " .. tostring(src))
+    local side = match.sides[src]
+
+    -- remove from player lists
+    match.alive[src] = nil
+    match.sides[src] = nil
+    for i, p in ipairs(match.players) do
+        if p == src then
+            table.remove(match.players, i)
+            break
+        end
+    end
+
+    local world = core.worlds[bucketId]
+    if world then
+        world.players[src] = nil
+    end
+
+    local winner = nil
+    if side == "A" then
+        winner = "B"
+    elseif side == "B" then
+        winner = "A"
+    end
+
+    print(("[erotic-core] %s left match %d (%s). Forcing end. Winner: %s")
+        :format(playerName, bucketId, match.gamemode, tostring(winner)))
+
+    core.endMatch(bucketId, winner)
 end

--- a/resources/erotic-core/server/queue.lua
+++ b/resources/erotic-core/server/queue.lua
@@ -11,6 +11,16 @@ function core.addToQueue(src, queueName)
         return
     end
 
+    if core.isPlayerInMatch(src) then
+        TriggerClientEvent("chat:addMessage", src, { args = { "[Arena]", "You are already in a match." } })
+        return
+    end
+
+    local currentWorld = core.getWorldByPlayer(src)
+    if currentWorld and currentWorld.gamemode ~= "lobby" then
+        core.leaveCurrentWorld(src, "queue")
+    end
+
     -- prevent double-queue
     for _, p in ipairs(queue.players) do
         if p == src then

--- a/resources/erotic-core/server/worlds.lua
+++ b/resources/erotic-core/server/worlds.lua
@@ -1,0 +1,389 @@
+core = core or {}
+
+core.worlds = core.worlds or {}
+core.personalWorlds = core.personalWorlds or {}
+core.bucketAllocator = core.bucketAllocator or { next = 2000, recycled = {} }
+
+local LOBBY_BUCKET = 0
+
+local function debugPrint(msg)
+    print(("[erotic-core][worlds] %s"):format(msg))
+end
+
+function core.allocateBucket(preferred)
+    if preferred and preferred ~= LOBBY_BUCKET then
+        if not core.worlds[preferred] then
+            return preferred
+        end
+    end
+
+    local recycled = table.remove(core.bucketAllocator.recycled)
+    if recycled then
+        return recycled
+    end
+
+    local nextId = core.bucketAllocator.next or 2000
+    core.bucketAllocator.next = nextId + 1
+    return nextId
+end
+
+function core.releaseBucket(bucket)
+    if not bucket or bucket == LOBBY_BUCKET then return end
+    table.insert(core.bucketAllocator.recycled, bucket)
+end
+
+function core.getWorld(bucket)
+    return core.worlds[bucket]
+end
+
+function core.getWorldByPlayer(src)
+    local bucket = GetPlayerRoutingBucket(src)
+    return core.worlds[bucket]
+end
+
+function core.isPlayerInMatch(src)
+    local world = core.getWorldByPlayer(src)
+    return world and world.type == "match"
+end
+
+local function makeWorldName(gamemode, metadata)
+    if metadata and metadata.name then
+        return metadata.name
+    end
+    local settings = core.gamemodeSettings[gamemode]
+    return (settings and settings.world and settings.world.name)
+        or (settings and gamemode:gsub("^%l", string.upper))
+        or gamemode
+end
+
+function core.registerWorld(bucket, gamemode, worldType, opts)
+    if core.worlds[bucket] then
+        local world = core.worlds[bucket]
+        if opts and opts.metadata then
+            world.metadata = world.metadata or {}
+            for k, v in pairs(opts.metadata) do
+                world.metadata[k] = v
+            end
+        end
+        return world
+    end
+
+    local settings = core.gamemodeSettings[gamemode] or {}
+    local worldCfg = settings.world or {}
+
+    local world = {
+        id = bucket,
+        bucket = bucket,
+        gamemode = gamemode,
+        type = worldType or worldCfg.type or "generic",
+        settings = settings,
+        config = worldCfg,
+        capacity = (opts and opts.capacity) or worldCfg.capacity,
+        owner = opts and opts.owner,
+        metadata = opts and opts.metadata or {},
+        players = {},
+        createdAt = os.time(),
+        name = makeWorldName(gamemode, opts and opts.metadata)
+    }
+
+    if opts and opts.players then
+        for _, src in ipairs(opts.players) do
+            world.players[src] = true
+        end
+    end
+
+    core.worlds[bucket] = world
+    debugPrint(("registered %s world in bucket %s"):format(gamemode, bucket))
+    return world
+end
+
+function core.destroyWorld(bucket, reason, opts)
+    local world = core.worlds[bucket]
+    if not world then return end
+
+    local skipPlayers = opts and opts.skipPlayerHandling
+
+    if not skipPlayers then
+        for src, _ in pairs(world.players) do
+            if GetPlayerPing(src) > 0 then
+                SetPlayerRoutingBucket(src, LOBBY_BUCKET)
+                TriggerClientEvent("erotic-core:setMode", src, "lobby")
+                TriggerClientEvent("erotic-core:arenaEndToLobby", src)
+
+                if world.gamemode == "ffa" then
+                    TriggerClientEvent("erotic-core:ffaExit", src)
+                elseif world.gamemode == "custom" then
+                    TriggerClientEvent("erotic-core:customWorldExit", src)
+                end
+            end
+        end
+    end
+
+    if world.type == "personal" and world.owner then
+        if core.personalWorlds[world.owner] == bucket then
+            core.personalWorlds[world.owner] = nil
+        end
+    end
+
+    core.worlds[bucket] = nil
+
+    if world.type ~= "static" then
+        core.releaseBucket(bucket)
+    end
+
+    debugPrint(("destroyed world %s (bucket %s) reason=%s"):format(world.name or world.gamemode, bucket, tostring(reason)))
+end
+
+function core.unregisterWorld(bucket)
+    core.destroyWorld(bucket, "unregister", { skipPlayerHandling = true })
+end
+
+local function ensureStaticWorld(gamemode)
+    local settings = core.gamemodeSettings[gamemode]
+    if not settings then return nil end
+    local worldCfg = settings.world or {}
+    local bucket = worldCfg.bucket or settings.bucket or LOBBY_BUCKET
+    return core.registerWorld(bucket, gamemode, "static", { metadata = { name = worldCfg.name } })
+end
+
+function core.updateWorldBlips(world)
+    if not world then return end
+    local settings = world.settings
+    if not settings or not settings.blips then return end
+
+    local players = {}
+    for id in pairs(world.players) do
+        table.insert(players, id)
+    end
+
+    for id in pairs(world.players) do
+        if GetPlayerPing(id) > 0 then
+            TriggerClientEvent("erotic-core:enableBlips", id, players, settings.blipInterval or 3000)
+        end
+    end
+end
+
+local function shouldBlockJoin(src)
+    if core.isPlayerInMatch(src) then
+        return true, "Finish your current match before switching arenas."
+    end
+    return false, nil
+end
+
+function core.leaveCurrentWorld(src, reason)
+    local bucket = GetPlayerRoutingBucket(src)
+    if bucket == LOBBY_BUCKET then
+        if GetPlayerPing(src) > 0 then
+            TriggerClientEvent("erotic-core:setMode", src, "lobby")
+        end
+        return nil
+    end
+
+    local world = core.worlds[bucket]
+    if not world then
+        if GetPlayerPing(src) > 0 then
+            SetPlayerRoutingBucket(src, LOBBY_BUCKET)
+            TriggerClientEvent("erotic-core:setMode", src, "lobby")
+            TriggerClientEvent("erotic-core:arenaEndToLobby", src)
+        end
+        return nil
+    end
+
+    world.players[src] = nil
+
+    if world.gamemode == "ffa" then
+        if GetPlayerPing(src) > 0 then
+            TriggerClientEvent("erotic-core:ffaExit", src)
+        end
+        core.updateWorldBlips(world)
+    elseif world.gamemode == "custom" then
+        if GetPlayerPing(src) > 0 then
+            TriggerClientEvent("erotic-core:customWorldExit", src)
+        end
+    end
+
+    if GetPlayerPing(src) > 0 then
+        SetPlayerRoutingBucket(src, LOBBY_BUCKET)
+        TriggerClientEvent("erotic-core:setMode", src, "lobby")
+        TriggerClientEvent("erotic-core:arenaEndToLobby", src)
+    end
+
+    if world.type == "personal" and not next(world.players) then
+        core.destroyWorld(bucket, "empty", { skipPlayerHandling = true })
+    end
+
+    return world
+end
+
+function core.joinWorldByBucket(bucket, src, opts)
+    local world = core.worlds[bucket]
+    if not world then
+        return false, "World not available"
+    end
+
+    local blocked, reason = shouldBlockJoin(src)
+    if blocked then
+        return false, reason
+    end
+
+    if world.capacity and core.tableCount(world.players) >= world.capacity and not (opts and opts.overrideCapacity) then
+        return false, "World is full"
+    end
+
+    if GetPlayerRoutingBucket(src) == bucket then
+        return true, world
+    end
+
+    if GetPlayerRoutingBucket(src) ~= LOBBY_BUCKET then
+        core.leaveCurrentWorld(src, "switch")
+    end
+
+    SetPlayerRoutingBucket(src, bucket)
+    world.players[src] = true
+
+    if GetPlayerPing(src) > 0 then
+        TriggerClientEvent("erotic-core:setMode", src, world.gamemode)
+        TriggerClientEvent("erotic-core:applyGameSettings", src, world.gamemode)
+    end
+
+    if world.gamemode == "ffa" then
+        TriggerClientEvent("erotic-core:ffaEnter", src, world.settings.spawns)
+        core.updateWorldBlips(world)
+    elseif world.gamemode == "custom" then
+        local settings = world.settings
+        local fallback = settings.defaultSpawn or vector4(231.1525, -1390.9653, 30.4999, 339.3951)
+        local spawn = (opts and opts.spawn) or world.metadata.spawn or fallback
+        TriggerClientEvent("erotic-core:customWorldEnter", src, {
+            name = world.name,
+            owner = world.owner,
+            spawn = spawn,
+            template = world.metadata.template
+        })
+    end
+
+    local label = GetPlayerName(src) or ("Player " .. tostring(src))
+    debugPrint(('%s joined world %s (bucket %s)'):format(label, world.name or world.gamemode, bucket))
+
+    return true, world
+end
+
+function core.joinGamemode(src, gamemode, opts)
+    local settings = core.gamemodeSettings[gamemode]
+    if not settings then
+        return false, "Gamemode not found"
+    end
+
+    local blocked, blockReason = shouldBlockJoin(src)
+    if blocked then
+        return false, blockReason
+    end
+
+    local worldCfg = settings.world or {}
+
+    if worldCfg.type == "static" then
+        local world = ensureStaticWorld(gamemode)
+        return core.joinWorldByBucket(world.bucket, src, opts)
+    elseif worldCfg.type == "personal" then
+        local world = core.createPersonalWorld(src, opts)
+        return core.joinWorldByBucket(world.bucket, src, opts)
+    elseif worldCfg.type == "match" then
+        return false, "queue"
+    else
+        local bucket = core.allocateBucket(worldCfg.bucket)
+        local world = core.registerWorld(bucket, gamemode, worldCfg.type or "dynamic", {
+            metadata = { name = worldCfg.name },
+            capacity = worldCfg.capacity
+        })
+        return core.joinWorldByBucket(world.bucket, src, opts)
+    end
+end
+
+function core.getPersonalWorldKey(src)
+    local user = core.users and core.users[src]
+    if user and user.arena_id then
+        return ("arena:%s"):format(user.arena_id)
+    end
+    return ("temp:%d"):format(src)
+end
+
+function core.findPersonalWorld(src)
+    local key = core.getPersonalWorldKey(src)
+    local bucket = core.personalWorlds[key]
+    if not bucket then return nil end
+    local world = core.worlds[bucket]
+    if not world then
+        core.personalWorlds[key] = nil
+        return nil
+    end
+    return world
+end
+
+function core.createPersonalWorld(src, opts)
+    local key = core.getPersonalWorldKey(src)
+    local existingBucket = core.personalWorlds[key]
+    if existingBucket and core.worlds[existingBucket] then
+        local world = core.worlds[existingBucket]
+        world.metadata.ownerSource = src
+        world.metadata.ownerName = GetPlayerName(src)
+        return world
+    end
+
+    local settings = core.gamemodeSettings.custom or {}
+    local bucket = core.allocateBucket()
+    local world = core.registerWorld(bucket, "custom", "personal", {
+        owner = key,
+        metadata = {
+            name = opts and opts.name or (GetPlayerName(src) .. "'s Arena"),
+            spawn = (opts and opts.spawn) or settings.defaultSpawn or vector4(231.1525, -1390.9653, 30.4999, 339.3951),
+            template = opts and opts.template or "default",
+            ownerSource = src,
+            ownerName = GetPlayerName(src)
+        },
+        capacity = settings.world and settings.world.capacity or nil
+    })
+
+    core.personalWorlds[key] = bucket
+    debugPrint(("created personal world %s for %s in bucket %s")
+        :format(world.name, GetPlayerName(src) or src, bucket))
+
+    return world
+end
+
+function core.joinPersonalWorld(src, opts)
+    local world = core.findPersonalWorld(src)
+    if not world then
+        world = core.createPersonalWorld(src, opts)
+    else
+        local key = core.getPersonalWorldKey(src)
+        if world.owner == key then
+            world.metadata = world.metadata or {}
+            world.metadata.ownerSource = src
+            world.metadata.ownerName = GetPlayerName(src)
+        end
+    end
+
+    local ok, err = core.joinWorldByBucket(world.bucket, src, opts)
+    if not ok then
+        return false, err
+    end
+
+    return true, world
+end
+
+function core.handleWorldOwnerLeft(src)
+    local key = core.getPersonalWorldKey(src)
+    local bucket = core.personalWorlds[key]
+    if not bucket then return end
+    local world = core.worlds[bucket]
+    if not world then
+        core.personalWorlds[key] = nil
+        return
+    end
+
+    if core.tableCount(world.players) == 0 then
+        core.destroyWorld(bucket, "owner disconnect", { skipPlayerHandling = true })
+    else
+        world.metadata.ownerSource = nil
+    end
+end
+*** End of File

--- a/resources/erotic-core/shared/core.lua
+++ b/resources/erotic-core/shared/core.lua
@@ -14,3 +14,15 @@ function core.getAllIdentifiers(src)
     end
     return identifiers
 end
+
+-- Utility: count table entries safely
+function core.tableCount(tbl)
+    if type(tbl) ~= "table" then return 0 end
+
+    local count = 0
+    for _ in pairs(tbl) do
+        count = count + 1
+    end
+
+    return count
+end

--- a/resources/erotic-core/shared/gamemodes.lua
+++ b/resources/erotic-core/shared/gamemodes.lua
@@ -9,6 +9,12 @@ core.gamemodeSettings = {
         helmets     = false,
         ragdoll     = false,
         spawningcars= false,
+        world       = {
+            type    = "static",
+            bucket  = 0,
+            capacity= nil,
+            name    = "Lobby"
+        }
     },
 
     ffa = {
@@ -25,6 +31,12 @@ core.gamemodeSettings = {
         spawns      = {
             vector4(90.0182, -1966.9272, 20.7473, 142.1477),
             vector4(85.7977, -1949.3544, 20.8465, 93.8788),
+        },
+        world       = {
+            type     = "static",
+            bucket   = 1000,
+            capacity = 48,
+            name     = "Global FFA"
         }
     },
 
@@ -37,7 +49,13 @@ core.gamemodeSettings = {
         helmets     = false,
         ragdoll     = false,
         spawningcars= false,
-        roundsToWin = 3
+        roundsToWin = 3,
+        world       = {
+            type     = "match",
+            capacity = 2,
+            queue    = true,
+            name     = "1v1 Duel"
+        }
     },
 
     ranked4v4 = {
@@ -64,6 +82,28 @@ core.gamemodeSettings = {
                 vector4(81.7, -1954.0, 20.8, 94.0),
                 vector4(79.7, -1956.0, 20.8, 94.0),
             }
+        },
+        world       = {
+            type     = "match",
+            capacity = 8,
+            queue    = true,
+            name     = "Ranked 4v4"
+        }
+    },
+
+    custom = {
+        blips        = false,
+        respawn      = false,
+        locals       = false,
+        headshots    = true,
+        helmets      = false,
+        ragdoll      = false,
+        spawningcars = false,
+        defaultSpawn = vector4(-1598.15, -3011.45, -78.25, 355.0),
+        world        = {
+            type      = "personal",
+            capacity  = 12,
+            name      = "Personal Arena"
         }
     }
 }

--- a/resources/ui/web/src/components/LobbyPage/LobbyPage.tsx
+++ b/resources/ui/web/src/components/LobbyPage/LobbyPage.tsx
@@ -21,8 +21,9 @@ const LobbyPage: React.FC<{ visible: boolean }> = ({ visible }) => {
       <h1 className="lobby-title">Arena Lobby</h1>
       <div className="lobby-buttons">
         <button onClick={() => handleJoin("ffa")}>Join FFA</button>
+        <button onClick={() => handleJoin("custom")}>Personal Arena</button>
         <button onClick={() => handleJoin("duel")}>Join Duel</button>
-        <button onClick={() => handleJoin("ranked4v4")}>Join 4v4</button>
+        <button onClick={() => handleJoin("ranked4v4")}>Join Ranked 4v4</button>
         <button onClick={handleLeave} className="leave-btn">Leave Lobby</button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add a reusable world manager that allocates buckets, registers worlds, and supports personal arenas
- wire queue, match, and ffa flows plus new lobby join/leave events into the world manager
- expose personal arenas and updated mode buttons through the lobby React UI and client events

## Testing
- npm run lint *(fails: ESLint configuration not yet migrated to eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d43efcf8cc83229b89fc112347de47